### PR TITLE
fixed webhook not doing connectOrCreate on new channel

### DIFF
--- a/src/db/extensions/reminders.ts
+++ b/src/db/extensions/reminders.ts
@@ -90,7 +90,17 @@ export default Prisma.defineExtension((prisma) => {
 										created_at: webhook.createdAt,
 										token: webhook.token,
 										url: webhook.url,
-										discord_channel_id: channelId,
+										discord_channels: {
+											connectOrCreate: {
+												where: {
+													id: channelId,
+												},
+												create: {
+													id: channelId,
+													name: resolveChannelName(channel),
+												},
+											},
+										},
 									},
 								},
 							},


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

@coderabbitai: ignore

- New Feature: Enhanced the `Prisma.defineExtension` function in `src/db/extensions/reminders.ts`. The update allows for connecting or creating a Discord channel based on the provided `channelId` and resolved channel name. This change improves the flexibility and robustness of our Discord integration, enabling more seamless interactions with various channels.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->